### PR TITLE
Retry on request timeout

### DIFF
--- a/src/deploy/upload-files.js
+++ b/src/deploy/upload-files.js
@@ -92,11 +92,14 @@ function retryUpload(uploadFn, maxRetry) {
         .then(results => resolve(results))
         .catch(e => {
           lastError = e
-          if (e.name === 'FetchError') {
-            console.log(e)
-            fibonacciBackoff.backoff()
-          } else {
-            return reject(e)
+          switch (true) {
+            case e.status === 408: // request timeout
+            case e.name === 'FetchError': {
+              return fibonacciBackoff.backoff()
+            }
+            default: {
+              return reject(e)
+            }
           }
         })
     }


### PR DESCRIPTION
**- Summary**

Handle request timeouts when uploading files.  Reported in https://github.com/netlify/cli/issues/161#issuecomment-433201317

**- Description for the changelog**

- Handle 408 request timeouts and retry when uploading files.

