### PR TITLE
Clean up tmp dir after deploys

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "parallel-transform": "^1.1.0",
     "pump": "^3.0.0",
     "qs": "^6.5.2",
+    "rimraf": "^2.6.3",
     "tempy": "^0.2.1",
     "through2-filter": "^3.0.0",
     "through2-map": "^3.0.0",
@@ -76,7 +77,6 @@
     "npm-run-all": "^4.1.3",
     "nyc": "^13.3.0",
     "prettier": "^1.16.4",
-    "rimraf": "^2.6.3",
     "webpack": "^4.29.5",
     "webpack-cli": "^3.2.3"
   },

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -3,6 +3,8 @@ const hashFiles = require('./hash-files')
 const hashFns = require('./hash-fns')
 const cleanDeep = require('clean-deep')
 const tempy = require('tempy')
+const promisify = require('util.promisify')
+const rimraf = promisify(require('rimraf'))
 const { waitForDiff } = require('./util')
 
 const { waitForDeploy, getUploadList, defaultFilter } = require('./util')
@@ -101,6 +103,8 @@ module.exports = async (api, siteId, dir, opts) => {
     msg: opts.draft ? 'Draft deploy is live!' : 'Deploy is live!',
     phase: 'stop'
   })
+
+  await rimraf(opts.tmpDir)
 
   const deployManifest = {
     deployId,


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/node-client/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

We were relying on the OS to clean up the temporary directory used for deploy prep.  This does it automatically now after the deploy succeeds.

**- Description for the changelog**

Clean up tmp dir after deploy instead of relying on the OS.

