### PR TITLE
Handle 422 response from all addons endpoints

### DIFF
--- a/src/addons.js
+++ b/src/addons.js
@@ -21,7 +21,7 @@ async function createAddon(settings, netlifyApiToken) {
   const data = await response.json()
 
   if (response.status === 422) {
-    throw new Error(`${JSON.stringify(data.error)}`)
+    throw new Error(data.error)
   }
 
   return data
@@ -40,7 +40,7 @@ async function getAddons(siteId, netlifyApiToken) {
   const data = await response.json()
 
   if (response.status === 422) {
-    throw new Error(`${JSON.stringify(data.error)}`)
+    throw new Error(data.error)
   }
 
   return data
@@ -60,7 +60,7 @@ async function deleteAddon(settings, netlifyApiToken) {
 
   if (response.status === 422) {
     const data = await response.json()
-    throw new Error(`${JSON.stringify(data.error)}`)
+    throw new Error(data.error)
   }
 
   return response
@@ -85,7 +85,7 @@ async function updateAddon(settings, netlifyApiToken) {
   const data = await response.json()
 
   if (response.status === 422) {
-    throw new Error(`${JSON.stringify(data.error)}`)
+    throw new Error(data.error)
   }
 
   return response

--- a/src/addons.js
+++ b/src/addons.js
@@ -21,7 +21,7 @@ async function createAddon(settings, netlifyApiToken) {
   const data = await response.json()
 
   if (response.status === 422) {
-    throw new Error(`Error ${JSON.stringify(data)}`)
+    throw new Error(`${JSON.stringify(data.error)}`)
   }
 
   return data
@@ -40,7 +40,7 @@ async function getAddons(siteId, netlifyApiToken) {
   const data = await response.json()
 
   if (response.status === 422) {
-    throw new Error(`Error ${JSON.stringify(data)}`)
+    throw new Error(`${JSON.stringify(data.error)}`)
   }
 
   return data
@@ -60,7 +60,7 @@ async function deleteAddon(settings, netlifyApiToken) {
 
   if (response.status === 422) {
     const data = await response.json()
-    throw new Error(`Error ${JSON.stringify(data)}`)
+    throw new Error(`${JSON.stringify(data.error)}`)
   }
 
   return response
@@ -85,7 +85,7 @@ async function updateAddon(settings, netlifyApiToken) {
   const data = await response.json()
 
   if (response.status === 422) {
-    throw new Error(`Error ${JSON.stringify(data)}`)
+    throw new Error(`${JSON.stringify(data.error)}`)
   }
 
   return response

--- a/src/addons.js
+++ b/src/addons.js
@@ -59,6 +59,7 @@ async function deleteAddon(settings, netlifyApiToken) {
   })
 
   if (response.status === 422) {
+    const data = await response.json()
     throw new Error(`Error ${JSON.stringify(data)}`)
   }
 
@@ -80,6 +81,8 @@ async function updateAddon(settings, netlifyApiToken) {
       config: config
     }),
   })
+
+  const data = await response.json()
 
   if (response.status === 422) {
     throw new Error(`Error ${JSON.stringify(data)}`)

--- a/src/addons.js
+++ b/src/addons.js
@@ -58,6 +58,10 @@ async function deleteAddon(settings, netlifyApiToken) {
     }
   })
 
+  if (response.status === 422) {
+    throw new Error(`Error ${JSON.stringify(data)}`)
+  }
+
   return response
 }
 
@@ -76,6 +80,10 @@ async function updateAddon(settings, netlifyApiToken) {
       config: config
     }),
   })
+
+  if (response.status === 422) {
+    throw new Error(`Error ${JSON.stringify(data)}`)
+  }
 
   return response
 }


### PR DESCRIPTION
**- Summary**

Netlify API will return 422 for error responses, especially when bypassing error responses from the addon providers. This was handled well with get and create, but not handled in update and delete.

Updating this will allow us to show the proper error message returned from the addon providers.

In the future, we can definitely improve `Error ${JSON.stringify(data)}` part. Netlify API actually always return in the JSON format like `{ error: "error message returned from addon providers"}`. We can start something as simple as changing it like `JSON.stringify(data).error` but I don't even know if it works with my JavaScript fu.

**- Test plan**

Good question. Where can I add tests? Run test locally and it passed.

**- Description for the changelog**

Handle 422 response from update/delete addon endpoints

**- A picture of a cute animal (not mandatory but encouraged)**

![image](https://user-images.githubusercontent.com/911433/58925874-fc583d80-86fd-11e9-85e2-82a6a8e54326.png)
