### PR TITLE
Only convert to json for failed response

### DIFF
--- a/src/addons.js
+++ b/src/addons.js
@@ -82,9 +82,8 @@ async function updateAddon(settings, netlifyApiToken) {
     }),
   })
 
-  const data = await response.json()
-
   if (response.status === 422) {
+    const data = await response.json()
     throw new Error(data.error)
   }
 


### PR DESCRIPTION
**- Summary**

With https://github.com/netlify/js-client/pull/51, we handled 422 better. However I was missing that the update endpoint actually returns 204 for the success case, which I can't convert it to json.
With this change, it only try to convert so when it returns 422.

**- Test plan**

N/A

**- Description for the changelog**

Only convert to json for failed addon update response (bug fix of #51 )

**- A picture of a cute animal (not mandatory but encouraged)**
