### PR TITLE
Remove `util.promisify` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
     "rimraf": "^2.6.3",
     "tempy": "^0.2.1",
     "through2-filter": "^3.0.0",
-    "through2-map": "^3.0.0",
-    "util.promisify": "^1.0.0"
+    "through2-map": "^3.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.4.3",

--- a/src/deploy/hash-files.js
+++ b/src/deploy/hash-files.js
@@ -1,5 +1,4 @@
 const { promisify } = require('util')
-
 const walker = require('folder-walker')
 const pump = promisify(require('pump'))
 const { hasherCtor, manifestCollectorCtor, fileFilterCtor, fileNormalizerCtor } = require('./hasher-segments')

--- a/src/deploy/hash-files.js
+++ b/src/deploy/hash-files.js
@@ -1,4 +1,5 @@
-const promisify = require('util.promisify')
+const { promisify } = require('util')
+
 const walker = require('folder-walker')
 const pump = promisify(require('pump'))
 const { hasherCtor, manifestCollectorCtor, fileFilterCtor, fileNormalizerCtor } = require('./hasher-segments')

--- a/src/deploy/hash-fns.js
+++ b/src/deploy/hash-fns.js
@@ -1,5 +1,4 @@
 const { promisify } = require('util')
-
 const pump = promisify(require('pump'))
 const fromArray = require('from2-array')
 const zipIt = require('@netlify/zip-it-and-ship-it')

--- a/src/deploy/hash-fns.js
+++ b/src/deploy/hash-fns.js
@@ -1,4 +1,5 @@
-const promisify = require('util.promisify')
+const { promisify } = require('util')
+
 const pump = promisify(require('pump'))
 const fromArray = require('from2-array')
 const zipIt = require('@netlify/zip-it-and-ship-it')

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -1,9 +1,10 @@
+const { promisify } = require('util')
+
 const uploadFiles = require('./upload-files')
 const hashFiles = require('./hash-files')
 const hashFns = require('./hash-fns')
 const cleanDeep = require('clean-deep')
 const tempy = require('tempy')
-const promisify = require('util.promisify')
 const rimraf = promisify(require('rimraf'))
 const { waitForDiff } = require('./util')
 

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -1,10 +1,9 @@
-const { promisify } = require('util')
-
 const uploadFiles = require('./upload-files')
 const hashFiles = require('./hash-files')
 const hashFns = require('./hash-fns')
 const cleanDeep = require('clean-deep')
 const tempy = require('tempy')
+const { promisify } = require('util')
 const rimraf = promisify(require('rimraf'))
 const { waitForDiff } = require('./util')
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,7 @@
+const test = require('ava')
 const { promisify } = require('util')
 const http = require('http')
 
-const test = require('ava')
 const NetlifyAPI = require('./index')
 const body = promisify(require('body'))
 const fromString = require('from2-string')

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,7 +1,6 @@
 const test = require('ava')
-const { promisify } = require('util')
 const http = require('http')
-
+const { promisify } = require('util')
 const NetlifyAPI = require('./index')
 const body = promisify(require('body'))
 const fromString = require('from2-string')

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,6 +1,7 @@
-const test = require('ava')
+const { promisify } = require('util')
 const http = require('http')
-const promisify = require('util.promisify')
+
+const test = require('ava')
 const NetlifyAPI = require('./index')
 const body = promisify(require('body'))
 const fromString = require('from2-string')


### PR DESCRIPTION
**- Summary**

The `util.promisify` dependency is not needed since [`util.promisify()`](https://nodejs.org/api/util.html#util_util_promisify_original) is supported since Node `8.0.0`, which is our Node.js target.

**- Description for the changelog**

Use native `util.promisify()` instead of ponyfill `util.promisify`.