### PR TITLE
Group `require()` statements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,7 +21,8 @@
         "args": "none",
         "ignoreRestSiblings": true
       }
-    ]
+    ],
+    "import/order": [2, { "newlines-between": "always" }]
   },
   "overrides": [
     {

--- a/src/deploy/hash-files.js
+++ b/src/deploy/hash-files.js
@@ -1,6 +1,8 @@
 const { promisify } = require('util')
+
 const walker = require('folder-walker')
 const pump = promisify(require('pump'))
+
 const { hasherCtor, manifestCollectorCtor, fileFilterCtor, fileNormalizerCtor } = require('./hasher-segments')
 
 module.exports = hashFiles

--- a/src/deploy/hash-files.test.js
+++ b/src/deploy/hash-files.test.js
@@ -1,7 +1,9 @@
+const path = require('path')
+
 const test = require('ava')
+
 const hashFiles = require('./hash-files')
 const { defaultFilter } = require('./util')
-const path = require('path')
 
 test('hashes files in a folder', async t => {
   const { files, filesShaMap } = await hashFiles(__dirname, path.resolve(__dirname, '../../fixtures/netlify.toml'), {

--- a/src/deploy/hash-fns.js
+++ b/src/deploy/hash-fns.js
@@ -1,8 +1,9 @@
 const { promisify } = require('util')
+const path = require('path')
+
 const pump = promisify(require('pump'))
 const fromArray = require('from2-array')
 const zipIt = require('@netlify/zip-it-and-ship-it')
-const path = require('path')
 
 const { hasherCtor, manifestCollectorCtor } = require('./hasher-segments')
 

--- a/src/deploy/hash-fns.test.js
+++ b/src/deploy/hash-fns.test.js
@@ -1,7 +1,8 @@
 const test = require('ava')
+const tempy = require('tempy')
+
 const hashFns = require('./hash-fns')
 const { defaultFilter } = require('./util')
-const tempy = require('tempy')
 
 test('hashes files in a folder', async t => {
   const { functions, fnShaMap } = await hashFns(__dirname, { filter: defaultFilter, tmpDir: tempy.directory() })

--- a/src/deploy/hasher-segments.js
+++ b/src/deploy/hasher-segments.js
@@ -1,9 +1,10 @@
 const objFilterCtor = require('through2-filter').objCtor
 const objWriter = require('flush-write-stream').obj
-const { normalizePath } = require('./util')
 const transform = require('parallel-transform')
 const hasha = require('hasha')
 const map = require('through2-map').obj
+
+const { normalizePath } = require('./util')
 
 // a parallel transform stream segment ctor that hashes fileObj's created by folder-walker
 exports.hasherCtor = ({ concurrentHash, hashAlgorithm = 'sha1' }) => {

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -1,12 +1,13 @@
-const uploadFiles = require('./upload-files')
-const hashFiles = require('./hash-files')
-const hashFns = require('./hash-fns')
+const { promisify } = require('util')
+
 const cleanDeep = require('clean-deep')
 const tempy = require('tempy')
-const { promisify } = require('util')
 const rimraf = promisify(require('rimraf'))
-const { waitForDiff } = require('./util')
 
+const hashFns = require('./hash-fns')
+const hashFiles = require('./hash-files')
+const uploadFiles = require('./upload-files')
+const { waitForDiff } = require('./util')
 const { waitForDeploy, getUploadList, defaultFilter } = require('./util')
 
 module.exports = async (api, siteId, dir, opts) => {

--- a/src/deploy/upload-files.js
+++ b/src/deploy/upload-files.js
@@ -1,5 +1,6 @@
-const pMap = require('p-map')
 const fs = require('fs')
+
+const pMap = require('p-map')
 const backoff = require('backoff')
 const debug = require('debug')('netlify:deploy')
 

--- a/src/deploy/util.js
+++ b/src/deploy/util.js
@@ -1,4 +1,5 @@
 const path = require('path')
+
 const pWaitFor = require('p-wait-for')
 const flatten = require('lodash.flatten')
 

--- a/src/deploy/util.test.js
+++ b/src/deploy/util.test.js
@@ -1,4 +1,5 @@
 const test = require('ava')
+
 const { normalizePath } = require('./util')
 
 test('normalizes relative file paths', t => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,11 @@
 const set = require('lodash.set')
 const get = require('lodash.get')
 const dfn = require('@netlify/open-api')
-const { methods, generateMethod } = require('./open-api')
 const pWaitFor = require('p-wait-for')
-const deploy = require('./deploy')
 const debug = require('debug')('netlify')
+
+const { methods, generateMethod } = require('./open-api')
+const deploy = require('./deploy')
 
 class NetlifyAPI {
   constructor(accessToken, opts) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,11 +1,14 @@
-const test = require('ava')
 const http = require('http')
 const { promisify } = require('util')
-const NetlifyAPI = require('./index')
+
+const test = require('ava')
 const body = promisify(require('body'))
 const fromString = require('from2-string')
 const { TextHTTPError } = require('micro-api-client')
+
 const { existy, unixNow } = require('./open-api/util')
+
+const NetlifyAPI = require('./index')
 
 const createServer = handler => {
   const s = http.createServer(handler)

--- a/src/open-api/index.js
+++ b/src/open-api/index.js
@@ -1,14 +1,16 @@
+const http = require('http')
+
 const get = require('lodash.get')
 const set = require('lodash.set')
 const queryString = require('qs')
-const http = require('http')
 const fetch = require('node-fetch').default || require('node-fetch') // Webpack will sometimes export default exports in different places
 const Headers = require('node-fetch').Headers
 const camelCase = require('lodash.camelcase')
 const { JSONHTTPError, TextHTTPError } = require('micro-api-client')
 const debug = require('debug')('netlify:open-api')
-const { existy, sleep, unixNow } = require('./util')
 const isStream = require('is-stream')
+
+const { existy, sleep, unixNow } = require('./util')
 
 exports.methods = require('./shape-swagger')
 

--- a/src/open-api/shape-swagger.js
+++ b/src/open-api/shape-swagger.js
@@ -1,4 +1,5 @@
 const dfn = require('@netlify/open-api')
+
 const { sortParams, mergeParams } = require('./util')
 const methods = []
 


### PR DESCRIPTION
**- Summary**

This ensures the `require()` statements are grouped: first the core modules, then the node modules, then the local imports. This is much easier to browse code when imports/require are on top of the file and grouped.

The `import/order` ESLint rule is added so that the grouping happens automatically on `eslint --fix`, i.e. we don't need to think about it. This happens on save if your IDE supports (VSCode does). 

**- Description for the changelog**

Group `require()` statements together.