### PR TITLE
Make `npm test` fail faster

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,10 +101,10 @@
     "prepublishOnly": "npm run build:webpack && git push && git push --tags && gh-release",
     "report": "nyc report --reporter=text-lcov | coveralls",
     "test": "run-s test:*",
-    "test:ava": "nyc --reporter=lcov ava --verbose && nyc report",
-    "test:deps": "dependency-check ./package.json --entry \"src/**/!(*.test).js\" --unused --missing --no-dev --no-peer",
     "test:lint": "eslint --fix 'src/**/*.js' '*.js'",
     "test:prettier": "prettier --write --loglevel warn 'src/**/*.js' '*.{js,md,yml,json}'",
+    "test:deps": "dependency-check ./package.json --entry \"src/**/!(*.test).js\" --unused --missing --no-dev --no-peer",
+    "test:ava": "nyc --reporter=lcov ava --verbose && nyc report",
     "watch": "nyc --reporter=lcov ava --watch",
     "clean": "rimraf dist coverage",
     "version": "auto-changelog -p --template keepachangelog --breaking-pattern breaking && git add CHANGELOG.md"


### PR DESCRIPTION
**- Summary**

At the moment `ava` is run before `eslint` or `prettier`. Since `eslint` and `prettier` are much faster and likely to fail, it makes more sense to move those first, so that `npm test` fails faster both locally and in CI.

**- Description for the changelog**

Make `npm test` fail faster.