### PR TITLE
Allow `accessToken` to be specified as an option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,8 @@ class NetlifyAPI {
         userAgent: 'netlify/js-client',
         scheme: dfn.schemes[0],
         host: dfn.host,
-        pathPrefix: dfn.basePath
+        pathPrefix: dfn.basePath,
+        accessToken
       },
       opts
     )
@@ -34,11 +35,7 @@ class NetlifyAPI {
     this.host = opts.host
     this.pathPrefix = opts.pathPrefix
     this.globalParams = Object.assign({}, opts.globalParams)
-
-    if (accessToken) {
-      debug('Setting access token')
-      this.accessToken = accessToken
-    }
+    this.accessToken = opts.accessToken
   }
 
   get accessToken() {


### PR DESCRIPTION
**- Summary**

We allow users calling `new NetlifyAPI(opts)` instead of `new NetlifyAPI(accessToken, opts)`.

However we also don't allow `opts.accessToken` to be defined. Users can set the `accessToken` using `api.accessToken = value`, but it would be more useful for them to do it directly from the options object.

**- Test plan**

A test was added as part of #68.

**- Description for the changelog**

Allow `accessToken` to be specified as an option.