### PR TITLE
Disable CI on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: '12'
 dist: bionic
 jobs:
   include:
-    - os: windows
+    # - os: windows
     - os: osx
     - node_js: '8.0.0'
     - node_js: '12'


### PR DESCRIPTION
**- Summary**

CI does not seem to work on Windows at the moment since it's been enabled by #62. This disables tests on Windows until this is fixes. Note that tests work for me on a Windows virtual machine.