### PR TITLE
Upgrade `zip-it-and-ship-it`

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   ],
   "dependencies": {
     "@netlify/open-api": "^0.13.2",
-    "@netlify/zip-it-and-ship-it": "^0.3.1",
+    "@netlify/zip-it-and-ship-it": "^0.4.0-9",
     "backoff": "^2.5.0",
     "clean-deep": "^3.0.2",
     "flush-write-stream": "^2.0.0",


### PR DESCRIPTION
This upgrades `zip-it-and-ship-it` to the latest version used inside Netlify Build.
This new version should be backward compatible, although it has not been tested with many real users yet.

This will ensure Netlify Build users are using consistent versions for `zip-it-and-ship-it` since that library is used separately by several projects: Netlify Build, Netlify CLI and the JavaScript client, which are requiring each other.

I suggest that we also upgrade it inside Netlify CLI. If there are issues in the beta version of `zip-it-and-ship-it`, it is better for us to catch those with local builds than with production builds. What do you think? @erquhart @RaeesBhatti 