### PR TITLE
Fix linting error

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "babel-loader": "^8.0.5",
     "eslint": "^5.16.0",
     "eslint-config-prettier": "^6.5.0",
-    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-import": "2.18.1",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-prettier": "^3.1.1",
     "from2-string": "^1.1.0",


### PR DESCRIPTION
CI tests are currently failing on Windows due to a bug in `eslint-plugin-import` (https://github.com/benmosher/eslint-plugin-import/issues/1405).

This bug was fixed 29 days ago. Unfortunately, no new release of `eslint-plugin-import` has been made yet. This PR downgrades this dependency until a new release is made.

Note: the CI tests are also failing to an unrelated bug solved by #91.