### PR TITLE
Reorganize development setup

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,5 +1,11 @@
 name: Build
-on: [push]
+on:
+  # Ensure GitHub actions are not run twice for same commits
+  push:
+    branches: [master]
+    tags: ['*']
+  pull_request:
+    types: [opened, synchronize, reopened]
 env:
   CI: 'true'
 jobs:
@@ -24,7 +30,11 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: Install dependencies
         run: npm install
+      - name: Linting
+        run: npm run format
       - name: Tests
-        run: npm run test-ci
+        run: npm run test:ci
+      - name: Build
+        run: npm run build
       - name: Codecov test coverage
-        run: bash scripts/coverage.sh "${{ secrets.CODECOV_TOKEN }}" "${{ matrix.os }}" "${{ matrix.node }}"
+        run: bash scripts/coverage.sh "${{ matrix.os }}" "${{ matrix.node }}"

--- a/ava.config.js
+++ b/ava.config.js
@@ -1,0 +1,6 @@
+export default {
+  files: ['src/**/*.test.js'],
+  compileEnhancements: false,
+  babel: false,
+  verbose: true
+}

--- a/package.json
+++ b/package.json
@@ -2,38 +2,34 @@
   "name": "netlify",
   "description": "Netlify Node.js API client",
   "version": "4.0.3",
-  "ava": {
-    "files": [
-      "src/**/*.test.js"
-    ],
-    "compileEnhancements": false,
-    "babel": false
-  },
   "files": [
     "src",
     "dist",
     "!*.test.js*",
     "!*~"
   ],
-  "main": "src/index.js",
+  "main": "./src/index.js",
   "unpkg": "./dist/main.js",
   "umd:main": "./dist/main.js",
   "browser": {
     "./src/deploy/index.js": "./src/deploy/index.browser.js"
   },
   "scripts": {
-    "prepublishOnly": "run-s build && git push && git push --tags && gh-release",
-    "ci": "run-s test build",
-    "test": "run-s test:* test:dev:*",
-    "test-ci": "run-s test:* test:ci:*",
-    "test:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"src/**/*.js\" \"*.js\"",
-    "test:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\"",
-    "test:dev:ava": "ava",
-    "test:ci:ava": "nyc -r lcovonly -r text -r json ava",
-    "build": "run-s build:*",
-    "build:webpack": "webpack",
-    "clean": "rimraf dist coverage",
-    "version": "auto-changelog -p --template keepachangelog --breaking-pattern breaking && npm run test:prettier && git add CHANGELOG.md"
+    "prepublishOnly": "npm run build && git push && git push --tags && gh-release",
+    "test": "npm run format && npm run test:dev",
+    "format": "run-s format:*",
+    "format:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"src/**/*.js\"",
+    "format:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\"",
+    "test:dev": "ava",
+    "test:ci": "nyc -r lcovonly -r text -r json ava",
+    "update-snapshots": "ava -u",
+    "build": "webpack",
+    "version": "auto-changelog -p --template keepachangelog --breaking-pattern breaking && npm run format:prettier && git add CHANGELOG.md"
+  },
+  "husky": {
+    "hooks": {
+      "pre-push": "npm run format"
+    }
   },
   "license": "MIT",
   "author": "Netlify Inc.",

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 # Upload test coverage to Codecov
 
-token="$1"
-
-os="$2"
+os="$1"
 os="${os/-latest/}"
 
-node="$3"
+node="$2"
 node="node_${node//./_}"
 
 curl -s https://codecov.io/bash | \
-  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -t "$token" -F "$os" -F "$node"
+  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -F "$os" -F "$node"


### PR DESCRIPTION
This does some reorganizing of the development setup to mirror the latest changes in `netlify/build`:
  - trigger GitHub actions on pull requests
  - separate linting, testing and building GitHub actions
  - do not pass Codecov token (since it's a public repository)
  - use `verbose: true` configuration property with Ava
  - re-order `package.json` properties
  - add Husky hook to lint/prettify on `git push`
  - re-organize and rename some npm scripts