### PR TITLE
Add http.Agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Create a new instance of the Netlify API client with the provided `accessToken`.
   host: 'api.netlify.com',
   pathPrefix: '/api/v1',
   accessToken: '1234myAccessToken',
+  agent: undefined, // e.g. HttpsProxyAgent
   globalParams: {} // parameters you want available for every request.
   // Global params are only sent of the OpenAPI spec specifies the provided params.
 }
@@ -190,6 +191,18 @@ Optional `opts` include:
     // for an example of how this can be used.
   }
  }
+```
+
+## Proxy support
+
+**Node.js only**: If this client is used behind a corporate proxy, you can pass an `HttpsProxyAgent` or any other `http.Agent` that can handle your situation as `agent` option:
+
+```js
+const HttpsProxyAgent = require('https-proxy-agent')
+
+const proxyUri = 'http(s)://[user:password@]proxyhost:port'
+const agent = new HttpsProxyAgent(proxyUri)
+const client = new NetlifyAPI('1234myAccessToken', { agent })
 ```
 
 ## UMD Builds

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,7 @@ class NetlifyAPI {
     this.pathPrefix = opts.pathPrefix
     this.globalParams = opts.globalParams
     this.accessToken = opts.accessToken
+    this.agent = opts.agent
   }
 
   get accessToken() {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,3 +1,5 @@
+const http = require('http')
+
 const test = require('ava')
 const fromString = require('from2-string')
 const { TextHTTPError, JSONHTTPError } = require('micro-api-client')
@@ -12,7 +14,13 @@ const pathPrefix = '/api/v10'
 const host = `${domain}:${port}`
 const origin = `${scheme}://${host}`
 const accessToken = 'testAccessToken'
-const agent = { key: 'value' }
+const agent = new http.Agent({
+  keepAlive: true,
+  keepAliveMsecs: 60000,
+  maxSockets: 10,
+  maxFreeSockets: 10,
+  timeout: 60000
+})
 
 const getClient = function(opts = {}) {
   return new NetlifyAPI(opts.accessToken, Object.assign({ scheme, host, pathPrefix }, opts))

--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -43,7 +43,8 @@ const getOpts = function({ verb, parameters }, NetlifyApi, { body }, opts) {
   const optsA = addHttpMethod(verb, opts)
   const optsB = addDefaultHeaders(NetlifyApi, optsA)
   const optsC = addBody(body, parameters, optsB)
-  return optsC
+  const optsD = addAgent(NetlifyApi, optsC)
+  return optsD
 }
 
 // Add the HTTP method based on the OpenAPI definition
@@ -56,6 +57,15 @@ const addDefaultHeaders = function(NetlifyApi, opts) {
   return Object.assign({}, opts, {
     headers: Object.assign({}, NetlifyApi.defaultHeaders, opts.headers)
   })
+}
+
+// Assign fetch agent (like for example HttpsProxyAgent) if there is one
+const addAgent = function(NetlifyApi, opts) {
+  if (NetlifyApi.agent) {
+    return Object.assign({}, opts, { agent: NetlifyApi.agent })
+  } else {
+    return opts
+  }
 }
 
 const makeRequestOrRetry = async function(url, opts) {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/node-client/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

If you want to use this Netlify JS client behind a corporate proxy, you need to be able to pass a proxy agent, like for example the [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent), to the underlying `node-fetch`. So I basically implemented what was suggested [here](https://github.com/netlify/cli/issues/170). 

With this, it should also be possible to handle other use cases and situations by using or even creating custom `http.Agent` implementations.
<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

**- Test plan**
- added three ava tests, those and the existing tests still pass
- successfully tested a Netlify site deployment by implementing this:
```js
const NetlifyAPI = require("netlify");
const HttpsProxyAgent = require("https-proxy-agent");

const proxyUri = "http://username:password@corporate-proxy-hostname:port";
const agent = new HttpsProxyAgent(proxyUri);
const client = new NetlifyAPI("myAccessToken", { agent });

async function deployeSite(siteId, buildDir, opts) {
  return await client.deploy(siteId, buildDir, opts);
}

deployeSite("mySiteId", "dist/my-project-build", {
  draft: true,
}).then((deploy) => console.log(deploy));
```
<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

**- Description for the changelog**
- add option named `agent` of type `http.Agent` to NetlifyClient opts, so that something like [https-proxy-agent](https://www.npmjs.com/package/https-proxy-agent) can be passed to the underlying `node-fetch`.
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

**- A picture of a cute animal (not mandatory but encouraged)**

![cute proxy animal](https://encrypted-tbn0.gstatic.com/images?q=tbn%3AANd9GcT6v0RdhJUdz01QXykSUS3ex4kWscF8knUWPrUh7BtyFMgkXlJN&usqp=CAU)