### PR TITLE
Recreate function body on retry

### DIFF
--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -31,9 +31,7 @@ const getMethod = function(method, NetlifyApi) {
 const callMethod = async function(method, NetlifyApi, params, opts) {
   const requestParams = Object.assign({}, NetlifyApi.globalParams, params)
   const url = getUrl(method, NetlifyApi, requestParams)
-  const optsA = getOpts(method, NetlifyApi, requestParams, opts)
-
-  const response = await makeRequestOrRetry(url, optsA)
+  const response = await makeRequestOrRetry({ url, method, NetlifyApi, requestParams, opts })
 
   const parsedResponse = await parseResponse(response)
   return parsedResponse
@@ -68,9 +66,10 @@ const addAgent = function(NetlifyApi, opts) {
   }
 }
 
-const makeRequestOrRetry = async function(url, opts) {
+const makeRequestOrRetry = async function({ url, method, NetlifyApi, requestParams, opts }) {
   for (let index = 0; index <= MAX_RETRY; index++) {
-    const response = await makeRequest(url, opts)
+    const optsA = getOpts(method, NetlifyApi, requestParams, opts)
+    const response = await makeRequest(url, optsA)
 
     if (shouldRetry(response, index)) {
       await waitForRetry(response)


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/node-client/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

When retrying a request that has a function as body, the body should be recreated for each request. This is required to be able to retry streams as they will be partially consumed by the previous attempt.

**- Test plan**

<!--
Demonstrate the code is solid.
Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
-->

The included test fails without the new behaviour to recreate the stream. This might be due to `nock`, but it matches the behaviour I am seeing when deploying against live servers. A request will get rate limited and be retried a minute later but fail with "Unprocessable Entity". When retrying again (with a manual retry mechanism outside of js-client around uploadDeployFile) it then succeeds when passing a new body.

**- Description for the changelog**

<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

Recreate request options when retrying a rate-limited API call.

**- A picture of a cute animal (not mandatory but encouraged)**

![puppy](https://user-images.githubusercontent.com/387068/86006728-b19b1900-ba16-11ea-9ab1-31b64b57aa75.jpeg)

