### PR TITLE
Improve Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["github>netlify/renovate-config:default"],
-  "ignorePresets": [":prHourlyLimit2"],
-  "semanticCommits": true,
-  "masterIssue": true
-}

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,0 +1,16 @@
+{
+  extends: ['github>netlify/renovate-config:default'],
+  ignorePresets: [':prHourlyLimit2'],
+  semanticCommits: true,
+  masterIssue: true,
+  automerge: false,
+  ignoreDeps: [
+    // Those cannot be upgraded until we drop support for Node 8
+    'ava',
+    'eslint',
+    'nock',
+    'p-map',
+    'prettier',
+    'tempy',
+  ],
+}


### PR DESCRIPTION
This improves the Renovate configuration:
  - Use `.json5` so we can add comments.
  - Disable automerge. One PR https://github.com/netlify/build/pull/1673 got automerged which might have broken builds.
  - Some dependencies cannot be upgraded until we drop support for Node 8. Add those to `ignoreDeps`.