### PR TITLE
Fix linting of lock files with Renovate

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "npm run format && npm run test:dev",
     "format": "run-s format:*",
     "format:lint": "eslint --ignore-path .gitignore --fix --cache --format=codeframe --max-warnings=0 \"src/**/*.js\"",
-    "format:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\"",
+    "format:prettier": "prettier --ignore-path .gitignore --write --loglevel warn \"src/**/*.js\" \"*.{js,md,yml,json}\" \"!package-lock.json\"",
     "test:dev": "ava",
     "test:ci": "nyc -r lcovonly -r text -r json ava",
     "update-snapshots": "ava -u",


### PR DESCRIPTION
Renovate indents `package-lock.json` differently from Prettier.
There does not seem to be an option to fix this.
So this PR disables Prettier on lock files.