### PR TITLE
Fix Codecov support

### DIFF
--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -7,5 +7,7 @@ os="${os/-latest/}"
 node="$2"
 node="node_${node//./_}"
 
+# We don't use the -Z flag (which makes CI build fail on upload error) because
+# Codecov fails wait too often.
 curl -s https://codecov.io/bash | \
-  bash -s -- -Z -y codecov.yml -f coverage/coverage-final.json -F "$os" -F "$node"
+  bash -s -- -f coverage/coverage-final.json -F "$os" -F "$node"


### PR DESCRIPTION
Codecov `-y` CLI flag was removed. `codecov.yml` is now automatically detected.