### PR TITLE
feat(command-deploy): support hidden deployment folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,12 +165,14 @@ The following paths can be passed in the options:
 
 - `configPath` (path to a `netlify.toml` file that includes redirect rules for the deploy, etc.)
 - `fnDir` (a folder with lambda functions to deploy)
+- `deployDir` (the name of the folder you want to deploy, should be the folder name referenced by `buildDir` above)
 
 Optional `opts` include:
 
 ```js
 {
   fnDir: null, // path to a folder of functions to deploy
+  deployDir: null // name of the folder in the `buildDir` path
   branch: null, // branch to pass onto the netlify api
   configPath: null, // path to a netlify.toml file to include in the deploy (e.g. redirect support for manual deploys)
   draft: false, // draft deploy or production deploy

--- a/src/deploy/hash-files.test.js
+++ b/src/deploy/hash-files.test.js
@@ -7,7 +7,7 @@ const { defaultFilter } = require('./util')
 
 test('hashes files in a folder', async t => {
   const { files, filesShaMap } = await hashFiles(__dirname, path.resolve(__dirname, '../../fixtures/netlify.toml'), {
-    filter: defaultFilter
+    filter: filePath => defaultFilter(filePath)
   })
   t.truthy(files['netlify.toml'], 'includes the netlify.toml file')
   Object.keys(files).forEach(path => t.truthy(path, 'each file has a path'))

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -21,7 +21,7 @@ module.exports = async (api, siteId, dir, opts) => {
       deployTimeout: 1.2e6, // local deploy timeout: 20 mins
       concurrentHash: 100, // concurrent file hash calls
       concurrentUpload: 15, // Number of concurrent uploads
-      filter: defaultFilter,
+      filter: filePath => defaultFilter(filePath, opts.deployDir),
       syncFileLimit: 7000, // number of files
       maxRetry: 5, // number of times to retry an upload
       statusCb: () => {

--- a/src/deploy/util.js
+++ b/src/deploy/util.js
@@ -3,14 +3,24 @@ const path = require('path')
 const flatten = require('lodash.flatten')
 const pWaitFor = require('p-wait-for')
 
-// Default filter when scanning for files
-exports.defaultFilter = filename => {
-  if (filename == null) return false
-  const n = path.basename(filename)
+const removeSlashes = path => path && path.replace(/\/+$/, '')
+
+/**
+ * Default filter when scanning for files
+ * @param {string} filePath - path to file to test filter on
+ * @param {string} [baseDir] - base directory to whitelist
+ */
+exports.defaultFilter = (filePath, baseDir = null) => {
+  if (filePath == null) return false
+  const fileName = path.basename(filePath)
+
+  // Always allow scanning files in the base directory
+  if (fileName === removeSlashes(baseDir)) return true
+
   switch (true) {
-    case n === 'node_modules':
-    case n.startsWith('.') && n !== '.well-known':
-    case n.match(/(\/__MACOSX|\/\.)/):
+    case fileName === 'node_modules':
+    case fileName.startsWith('.') && fileName !== '.well-known':
+    case fileName.match(/(\/__MACOSX|\/\.)/):
       return false
     default:
       return true


### PR DESCRIPTION
**- Summary**

This PR aims to fix an issue opened in the `netlify/cli` repository: https://github.com/netlify/cli/issues/1227

The issue here is that the `defaultFilter` function aims to ignore hidden files within the deploy directory (which makes sense). Since it is not aware of the actual name of the deploy directory, it currently filters out the directory itself. 

By creating a closure to encapsulate the new `deployDir` option, we can pass the name of the deploy folder into the filter and allow filtering inside that folder.

**- Test plan**

```sh
npx @docusaurus/init@next init my-website classic
cd my-website
mkdir .build
vim .build/index.html

# Insert some HTML into the file and save it
netlify deploy -d .build
```

Given these steps, Netlify should properly find and hash the files inside `.build`

**- Description for the changelog**

feat(command-deploy): support hidden deployment folders with `-d` flag

**- A picture of a cute animal (not mandatory but encouraged)**

![luna](https://user-images.githubusercontent.com/8846086/93030679-b44ee880-f5d9-11ea-9fbd-36fb3ad906d1.jpg)



