### PR TITLE
Update syncFileLimit to 100

### DIFF
--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -22,7 +22,7 @@ module.exports = async (api, siteId, dir, opts) => {
       concurrentHash: 100, // concurrent file hash calls
       concurrentUpload: 15, // Number of concurrent uploads
       filter: defaultFilter,
-      syncFileLimit: 7000, // number of files
+      syncFileLimit: 100, // number of files
       maxRetry: 5, // number of times to retry an upload
       statusCb: () => {
         /* default to noop */


### PR DESCRIPTION
**- Summary**

So we have the same value as CLI: https://github.com/netlify/cli/blob/aa2f348e669a460fed1f6a46068c4457e9b40733/src/commands/deploy.js#L210
Most deploys perform better with the async flow. See https://github.com/netlify/cli/pull/966 for context

**- Test plan**
Test pass.

**- Description for the changelog**

- Update default `syncFileLimit` to 100


**- A picture of a cute animal (not mandatory but encouraged)**
![](https://i.redd.it/uscg8oa1ell51.jpg)