### PR TITLE
feat(deploy): allow updating an existing deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ Optional `opts` include:
         } */
     // See https://github.com/netlify/cli/blob/v2.0.0-beta.3/src/commands/deploy.js#L161-L195
     // for an example of how this can be used.
-  }
+  },
+  // passing a deployId will update an existing deploy based on the provided options
+  deployId: null
  }
 ```
 

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -78,7 +78,9 @@ module.exports = async (api, siteId, dir, opts) => {
     }
   })
   if (opts.deployId === null) {
-    deployParams = { ...deployParams, ...(title && { title }) }
+    if(title) {
+      deployParams = { ...deployParams, title }
+    }
     deploy = await api.createSiteDeploy(deployParams)
   } else {
     deployParams = { ...deployParams, deploy_id: opts.deployId }

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -32,7 +32,9 @@ module.exports = async (api, siteId, dir, opts) => {
             phase: [start, progress, stop],
             spinner: a spinner from cli-spinners package
         } */
-      }
+      },
+      // allows updating an existing deploy
+      deployId: null
     },
     opts
   )
@@ -64,9 +66,9 @@ module.exports = async (api, siteId, dir, opts) => {
     phase: 'start'
   })
 
-  const deployParams = cleanDeep({
+  let deploy
+  let deployParams = cleanDeep({
     siteId,
-    title,
     body: {
       files,
       functions,
@@ -75,8 +77,14 @@ module.exports = async (api, siteId, dir, opts) => {
       draft: opts.draft
     }
   })
+  if (opts.deployId === null) {
+    deployParams = { ...deployParams, ...(title && { title }) }
+    deploy = await api.createSiteDeploy(deployParams)
+  } else {
+    deployParams = { ...deployParams, deploy_id: opts.deployId }
+    deploy = await api.updateSiteDeploy(deployParams)
+  }
 
-  let deploy = await api.createSiteDeploy(deployParams)
   if (deployParams.body.async) deploy = await waitForDiff(api, deploy.id, siteId, opts.deployTimeout)
 
   const { id: deployId, required: requiredFiles, required_functions: requiredFns } = deploy


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/1236

Allows passing in an existing deploy to update.
This is required since deploying edge handlers must be done before the deploy is complete.
At the moment the whole deploy cycle happens in the `js-client` which doesn't allow deploying edge handlers.
This change allows creating the deploy in the CLI and finalising it in the `js-client`.

**- Test plan**

Ran different variations of the deploy command from the CLI.

**- Description for the changelog**

Allow updating an existing deploy when invoking the deploy function.

**- A picture of a cute animal (not mandatory but encouraged)**

🦁 