### PR TITLE
fix(deploy): don't hang when there are no files to deploy

### DIFF
--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -52,13 +52,18 @@ module.exports = async (api, siteId, dir, opts) => {
     hashFns(fnDir, opts)
   ])
 
+  const filesCount = Object.keys(files).length
+  const functionsCount = Object.keys(functions).length
+
   statusCb({
     type: 'hashing',
-    msg:
-      `Finished hashing ${Object.keys(files).length} files` +
-      (fnDir ? ` and ${Object.keys(functions).length} functions` : ''),
+    msg: `Finished hashing ${filesCount} files` + (fnDir ? ` and ${functionsCount} functions` : ''),
     phase: 'stop'
   })
+
+  if (filesCount === 0 && functionsCount === 0) {
+    throw new Error('No files or functions to deploy')
+  }
 
   statusCb({
     type: 'create-deploy',


### PR DESCRIPTION
**- Summary**

Related to https://github.com/netlify/cli/issues/1227.
Going to follow up with a CLI matching PR.

At the moment the deploy command hangs if there are no files to deploy.
This can happen when running `netlify deploy --dir public` on a project with an empty `public` directory and no `netlify.toml` file (see issue above).

The state of deploy remains `new` so the following code hangs:
https://github.com/netlify/js-client/blob/55650048fc7fe6288816c1dc172b27024cbd1586/src/deploy/util.js#L47

**- Test plan**

Will test this in the CLI repo.

**- Description for the changelog**

Throw an error when `deploy` is called and there are no files to deploy (previously hanged).

**- A picture of a cute animal (not mandatory but encouraged)**

🐱 

> The flow can be further improved when we do https://github.com/netlify/js-client/issues/157 