### PR TITLE
Retry on `ETIMEDOUT` timeout

### DIFF
--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -69,21 +69,28 @@ const addAgent = function(NetlifyApi, opts) {
 const makeRequestOrRetry = async function({ url, method, NetlifyApi, requestParams, opts }) {
   for (let index = 0; index <= MAX_RETRY; index++) {
     const optsA = getOpts(method, NetlifyApi, requestParams, opts)
-    const response = await makeRequest(url, optsA)
+    const { response, error } = await makeRequest(url, optsA)
 
-    if (shouldRetry(response, index)) {
+    if (shouldRetry({ response, error }) && index !== MAX_RETRY) {
       await waitForRetry(response)
-    } else {
-      return response
+      continue
     }
+
+    if (error !== undefined) {
+      throw error
+    }
+
+    return response
   }
 }
 
 const makeRequest = async function(url, opts) {
   try {
-    return await fetch(url, opts)
+    const response = await fetch(url, opts)
+    return { response }
   } catch (error) {
-    throw getFetchError(error, url, opts)
+    const errorA = getFetchError(error, url, opts)
+    return { error: errorA }
   }
 }
 

--- a/src/methods/retry.js
+++ b/src/methods/retry.js
@@ -1,6 +1,8 @@
-// When the API is rate limiting, the request is retried later
-const shouldRetry = function(response, index) {
-  return response.status === RATE_LIMIT_STATUS && index !== MAX_RETRY
+// We retry:
+//  - when receiving a rate limiting response
+//  - on network failures due to timeouts
+const shouldRetry = function({ response = {}, error = {} }) {
+  return response.status === RATE_LIMIT_STATUS || RETRY_ERROR_CODES.includes(error.code)
 }
 
 const waitForRetry = async function(response) {
@@ -8,8 +10,12 @@ const waitForRetry = async function(response) {
   await sleep(delay)
 }
 
-const getDelay = function({ headers }) {
-  const rateLimitReset = headers.get(RATE_LIMIT_HEADER)
+const getDelay = function(response) {
+  if (response === undefined) {
+    return DEFAULT_RETRY_DELAY
+  }
+
+  const rateLimitReset = response.headers.get(RATE_LIMIT_HEADER)
 
   if (!rateLimitReset) {
     return DEFAULT_RETRY_DELAY
@@ -28,5 +34,6 @@ const SECS_TO_MSECS = 1e3
 const MAX_RETRY = 10
 const RATE_LIMIT_STATUS = 429
 const RATE_LIMIT_HEADER = 'X-RateLimit-Reset'
+const RETRY_ERROR_CODES = ['ETIMEDOUT']
 
 module.exports = { shouldRetry, waitForRetry, MAX_RETRY }


### PR DESCRIPTION
Fixes #166.

When the TCP connection or HTTP request times out, an error with `code: 'ETIMEDOUT'` is usually thrown by `node-fetch` (as opposed to returning a `4**` or 5**` error response).

This PR retries the request up to 10 times, with a fixed 5 seconds between each request. After that, it gives and propagate the `ETIMEDOUT` error.