### PR TITLE
align js-client upload limits with api ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Optional `opts` include:
   message: undefined, // a short message to associate with the deploy
   deployTimeout: 1.2e6, // 20 mins
   parallelHash: 100, // number of parallel hashing calls
-  parallelUpload: 15, // number of files to upload in parallel
+  parallelUpload: 5, // number of files to upload in parallel
   maxRetry: 5, // number of times to try on failed file uploads
   filter: filepath => { /* return false to filter a file  from the deploy */ },
   tmpDir: tempy.directory(), // a temporary directory to zip functions into

--- a/src/deploy/index.js
+++ b/src/deploy/index.js
@@ -20,7 +20,7 @@ module.exports = async (api, siteId, dir, opts) => {
       tmpDir: tempy.directory(),
       deployTimeout: 1.2e6, // local deploy timeout: 20 mins
       concurrentHash: 100, // concurrent file hash calls
-      concurrentUpload: 15, // Number of concurrent uploads
+      concurrentUpload: 5, // Number of concurrent uploads
       filter: defaultFilter,
       syncFileLimit: 100, // number of files
       maxRetry: 5, // number of times to retry an upload


### PR DESCRIPTION
**- Summary**
part of aligning our concurrency limits across our platform, we need to update the js-client to reflect the same values as enforced by our API https://github.com/netlify/bitballoon/issues/5842 and https://github.com/netlify/bitballoon/issues/5624 (**internal**)
This is a fix for https://github.com/netlify/js-client/issues/178 - thank you @kaganjd for opening the issue ❤️ 

**- Test plan**
This shouldn't impact current deploy behaviour as this limit has been enabled since the 9th of September at the API level.

**- Description for the changelog**

Limiting abusive client uploads by enforcing a unified concurrency limit for js-clients across the Netlify Platform

**- A picture of a cute animal (not mandatory but encouraged)**
![](https://hips.hearstapps.com/hmg-prod.s3.amazonaws.com/images/funny-dog-halloween-costumes-1600276912.jpg)
