### PR TITLE
Improve `renovate.json5`

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,11 +4,23 @@
   semanticCommits: true,
   masterIssue: true,
   automerge: false,
-  ignoreDeps: [
-    // Those cannot be upgraded until we drop support for Node 8
-    'ava',
-    'nock',
-    'p-map',
-    'tempy',
+  packageRules: [
+    {
+      packagePatterns: ['^@netlify', '^netlify'],
+      groupName: 'netlify packages',
+      schedule: null,
+    },
+    {
+      // Those cannot be upgraded to a major version until we drop support for Node 8
+      packageNames: [
+        'ava',
+        'nock',
+        'p-map',
+        'tempy',
+      ],
+      major: {
+        enabled: false,
+      },
+    },
   ],
 }


### PR DESCRIPTION
This improves the Renovate config so new Netlify packages are creating PRs right away.