### PR TITLE
Remove `lodash.flatten`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,7 +28,6 @@ module.exports = {
     'promise/prefer-await-to-callbacks': 0,
     'promise/prefer-await-to-then': 0,
     'unicorn/filename-case': 0,
-    'you-dont-need-lodash-underscore/flatten': 0,
   },
   overrides: [...overrides],
 }

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
     "from2-array": "0.0.4",
     "hasha": "^5.0.0",
     "lodash.camelcase": "^4.3.0",
-    "lodash.flatten": "^4.4.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
     "micro-api-client": "^3.3.0",

--- a/src/deploy/util.js
+++ b/src/deploy/util.js
@@ -1,6 +1,5 @@
 const path = require('path')
 
-const flatten = require('lodash.flatten')
 const pWaitFor = require('p-wait-for')
 
 // Default filter when scanning for files
@@ -106,7 +105,8 @@ const waitForDeploy = async (api, deployId, siteId, timeout) => {
 // Transform the fileShaMap and fnShaMap into a generic shaMap that file-uploader.js can use
 const getUploadList = (required, shaMap) => {
   if (!required || !shaMap) return []
-  return flatten(required.map((sha) => shaMap[sha]))
+  // TODO: use `Array.flatMap()` instead once we remove support for Node <11.0.0
+  return [].concat(...required.map((sha) => shaMap[sha]))
 }
 
 module.exports = {


### PR DESCRIPTION
This removes `lodash.flatten`, replacing with vanilla JavaScript instead.