### PR TITLE
Simplify a unit test

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     'fp/no-mutation': 0,
     'fp/no-this': 0,
     'node/global-require': 0,
-    'node/prefer-global/process': 0,
     'promise/no-callback-in-promise': 0,
     'promise/prefer-await-to-callbacks': 0,
     'promise/prefer-await-to-then': 0,

--- a/src/deploy/util.test.js
+++ b/src/deploy/util.test.js
@@ -1,27 +1,12 @@
+const { join } = require('path')
+
 const test = require('ava')
 
 const { normalizePath, defaultFilter } = require('./util')
 
 test('normalizes relative file paths', (t) => {
-  const cases = [
-    {
-      input: 'foo/bar/baz.js',
-      expect: 'foo/bar/baz.js',
-      msg: 'relative paths are normalized',
-      skip: process.platform === 'win32',
-    },
-    {
-      input: 'beep\\impl\\bbb',
-      expect: 'beep/impl/bbb',
-      msg: 'relative windows paths are normalized',
-      skip: process.platform !== 'win32',
-    },
-  ]
-
-  cases.forEach((c) => {
-    if (c.skip) return
-    t.is(normalizePath(c.input), c.expect, c.msg)
-  })
+  const input = join('foo', 'bar', 'baz.js')
+  t.is(normalizePath(input), 'foo/bar/baz.js')
 })
 
 test('normalizePath should throw the error if name is invalid', (t) => {


### PR DESCRIPTION
This simplifies a unit test (which really should not really exist in the first place, since the source code should just use some `path.*` method).