### PR TITLE
Enable `max-nested-callbacks` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,6 @@ module.exports = {
   rules: {
     // TODO: enable those rules
     complexity: 0,
-    'max-nested-callbacks': 0,
     'max-statements': 0,
     'no-await-in-loop': 0,
     'fp/no-class': 0,


### PR DESCRIPTION
This enables the `max-nested-callbacks` ESLint rule.