### PR TITLE
Enable `promise/no-callback-in-promise` ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,6 @@ module.exports = {
     'fp/no-let': 0,
     'fp/no-loops': 0,
     'fp/no-mutation': 0,
-    'promise/no-callback-in-promise': 0,
     'promise/prefer-await-to-callbacks': 0,
   },
   overrides: [...overrides],


### PR DESCRIPTION
This enables the `promise/no-callback-in-promise` ESLint rule.