### PR TITLE
uses open library instead of openBrowser function

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,12 +163,14 @@ See the [authenticating](https://www.netlify.com/docs/api/#authenticating) docs 
 
 ```js
 // example:
+const open = require('open') // installed with 'npm i open'
+
 const login = async () => {
   const ticket = await api.createTicket({
     clientId: CLIENT_ID,
   })
   // Open browser for authentication
-  await openBrowser(`https://app.netlify.com/authorize?response_type=ticket&ticket=${ticket.id}`)
+  await open(`https://app.netlify.com/authorize?response_type=ticket&ticket=${ticket.id}`)
   const accessToken = await api.getAccessToken(ticket)
   // API is also set up to use the returned access token as a side effect
   return accessToken // Save this for later so you can quickly set up an authenticated client

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ See the [authenticating](https://www.netlify.com/docs/api/#authenticating) docs 
 const open = require('open') // installed with 'npm i open'
 
 const login = async () => {
-  const ticket = await api.createTicket({
+  const ticket = await client.createTicket({
     clientId: CLIENT_ID,
   })
   // Open browser for authentication
   await open(`https://app.netlify.com/authorize?response_type=ticket&ticket=${ticket.id}`)
-  const accessToken = await api.getAccessToken(ticket)
+  const accessToken = await client.getAccessToken(ticket)
   // API is also set up to use the returned access token as a side effect
   return accessToken // Save this for later so you can quickly set up an authenticated client
 }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

Please make sure you've read and understood our contributing guidelines;
https://github.com/netlify/node-client/blob/master/CONTRIBUTING.md

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx", where #xxxx is the issue number.

Please provide enough information so that others can review your pull request.
The first three fields are mandatory:
-->

**- Summary**

<!--
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

For the authorization example in the `README.md`, switches out the use of the `openBrowser` function to the [open library](https://github.com/sindresorhus/open) as suggested by @ehmicky. This makes the example a little more encapsulated.

**- A picture of a cute animal (not mandatory but encouraged)**
![main-qimg-0ed1eb8b029f487633cce500ceac79fa](https://user-images.githubusercontent.com/3611928/103862745-a55edb00-508d-11eb-857f-02d284a14173.jpg)