### PR TITLE
feature: drop Node.js 8 support

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,12 +13,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        node-version: [8.17.0, 14.x]
+        node-version: [10.18.0, 14.x]
         exclude:
           - os: macOS-latest
-            node-version: 8.17.0
+            node-version: 10.18.0
           - os: windows-latest
-            node-version: 8.17.0
+            node-version: 10.18.0
       fail-fast: false
     steps:
       - name: Git checkout

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "webpack-cli": "^4.0.0"
   },
   "engines": {
-    "node": ">=8.3.0"
+    "node": ">=10.18.0"
   },
   "ava": {
     "files": [

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,13 +4,4 @@
   semanticCommits: true,
   masterIssue: true,
   automerge: false,
-  packageRules: [
-    {
-      // Those cannot be upgraded to a major version until we drop support for Node 8
-      packageNames: ['ava', 'nock', 'p-map', 'tempy'],
-      major: {
-        enabled: false,
-      },
-    },
-  ],
 }


### PR DESCRIPTION
**- Summary**

Fixes https://github.com/netlify/js-client/issues/270

**- Test plan**

Updated CI to run on Node.js 10

**- Description for the changelog**

Drop Node.js 8 support

**- A picture of a cute animal (not mandatory but encouraged)**
![image](https://user-images.githubusercontent.com/26760571/104191646-70a0aa00-5426-11eb-8268-8a234bb06541.png)
