### PR TITLE
chore: use personal access token in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
           release-type: node
           package-name: 'netlify'


### PR DESCRIPTION
This makes sure status checks are run for release please PRs