### PR TITLE
chore: change renovate strategy

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,6 +4,7 @@
   semanticCommits: true,
   masterIssue: true,
   automerge: false,
+  rangeStrategy: 'bump',
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 8


### PR DESCRIPTION
Trying to see if this bumps `package.json` too in addition to the lock file