### PR TITLE
fix: fix `package.json` and `files` in `package.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -135,6 +135,46 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/eslint-parser": {
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.12.16.tgz",
+      "integrity": "sha512-NZHtJr2pLRYcQjvo/GVU3kFxIGEHveswoWfY5Wm2tJ7pb3AoqoQ+PP17rRTDh+POFWM15VvH+23x2/9Od0CYxQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-scope": "5.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || >=14.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": ">=7.11.0",
+        "eslint": ">=7.5.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/eslint-scope": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/generator": {
       "version": "7.12.15",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.15.tgz",
@@ -4174,16 +4214,16 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz",
-      "integrity": "sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
+      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
       "dev": true,
       "dependencies": {
         "is-text-path": "^1.0.1",
         "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
-        "split2": "^2.0.0",
+        "split2": "^3.0.0",
         "through2": "^4.0.0",
         "trim-off-newlines": "^1.0.0"
       },
@@ -5378,9 +5418,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.3.664",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.664.tgz",
-      "integrity": "sha512-yb8LrTQXQnh9yhnaIHLk6CYugF/An50T20+X0h++hjjhVfgSp1DGoMSYycF8/aD5eiqS4QwaNhiduFvK8rifRg==",
+      "version": "1.3.667",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.667.tgz",
+      "integrity": "sha512-Ot1pPtAVb5nd7jeVF651zmfLFilRVFomlDzwXmdlWe5jyzOGa6mVsQ06XnAurT7wWfg5VEIY+LopbAdD/bpo5w==",
       "dev": true
     },
     "node_modules/elf-cam": {
@@ -6456,12 +6496,13 @@
       }
     },
     "node_modules/eslint-template-visitor": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.2.2.tgz",
-      "integrity": "sha512-SkcLjzKw3JjKTWHacRDeLBa2gxb600zbCKTkXj/V97QnZ9yxkknoPL8vc8PFueqbFXP7mYNTQzjCjcMpTRdRaA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.1.tgz",
+      "integrity": "sha512-K/76IDGPVbnb6bLkycR5MbVMJ3ERrZIYyLB2/+2JfqGrrIrjiQvSVLtmgTQYj1YJ/ibYG3eFyrwXHwu0f0q6Jg==",
       "dev": true,
       "dependencies": {
-        "babel-eslint": "^10.1.0",
+        "@babel/core": "^7.12.16",
+        "@babel/eslint-parser": "^7.12.16",
         "eslint-visitor-keys": "^2.0.0",
         "esquery": "^1.3.1",
         "multimap": "^1.1.0"
@@ -7712,15 +7753,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/split2": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "^3.0.0"
       }
     },
     "node_modules/git-raw-commits/node_modules/strip-indent": {
@@ -12989,46 +13021,12 @@
       }
     },
     "node_modules/split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "dev": true,
       "dependencies": {
-        "through2": "^2.0.2"
-      }
-    },
-    "node_modules/split2/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-      "dev": true,
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/split2/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
-    "node_modules/split2/node_modules/through2": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-      "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-      "dev": true,
-      "dependencies": {
-        "readable-stream": "~2.3.6",
-        "xtend": "~4.0.1"
+        "readable-stream": "^3.0.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -13452,9 +13450,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
-      "integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
+      "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -15220,9 +15218,9 @@
       }
     },
     "node_modules/webpack-cli/node_modules/commander": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.0.0.tgz",
-      "integrity": "sha512-ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
+      "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
       "dev": true,
       "engines": {
         "node": ">= 10"
@@ -15843,6 +15841,35 @@
         "lodash": "^4.17.19",
         "semver": "^5.4.1",
         "source-map": "^0.5.0"
+      }
+    },
+    "@babel/eslint-parser": {
+      "version": "7.12.16",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.12.16.tgz",
+      "integrity": "sha512-NZHtJr2pLRYcQjvo/GVU3kFxIGEHveswoWfY5Wm2tJ7pb3AoqoQ+PP17rRTDh+POFWM15VvH+23x2/9Od0CYxQ==",
+      "dev": true,
+      "requires": {
+        "eslint-scope": "5.1.0",
+        "eslint-visitor-keys": "^1.3.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "eslint-scope": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
+          "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+          "dev": true,
+          "requires": {
+            "esrecurse": "^4.1.0",
+            "estraverse": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/generator": {
@@ -19145,16 +19172,16 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.0.tgz",
-      "integrity": "sha512-XmJiXPxsF0JhAKyfA2Nn+rZwYKJ60nanlbSWwwkGwLQFbugsc0gv1rzc7VbbUWAzJfR1qR87/pNgv9NgmxtBMQ==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
+      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
       "dev": true,
       "requires": {
         "is-text-path": "^1.0.1",
         "JSONStream": "^1.0.4",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
-        "split2": "^2.0.0",
+        "split2": "^3.0.0",
         "through2": "^4.0.0",
         "trim-off-newlines": "^1.0.0"
       },
@@ -20092,9 +20119,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.664",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.664.tgz",
-      "integrity": "sha512-yb8LrTQXQnh9yhnaIHLk6CYugF/An50T20+X0h++hjjhVfgSp1DGoMSYycF8/aD5eiqS4QwaNhiduFvK8rifRg==",
+      "version": "1.3.667",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.667.tgz",
+      "integrity": "sha512-Ot1pPtAVb5nd7jeVF651zmfLFilRVFomlDzwXmdlWe5jyzOGa6mVsQ06XnAurT7wWfg5VEIY+LopbAdD/bpo5w==",
       "dev": true
     },
     "elf-cam": {
@@ -21004,12 +21031,13 @@
       }
     },
     "eslint-template-visitor": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.2.2.tgz",
-      "integrity": "sha512-SkcLjzKw3JjKTWHacRDeLBa2gxb600zbCKTkXj/V97QnZ9yxkknoPL8vc8PFueqbFXP7mYNTQzjCjcMpTRdRaA==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-template-visitor/-/eslint-template-visitor-2.3.1.tgz",
+      "integrity": "sha512-K/76IDGPVbnb6bLkycR5MbVMJ3ERrZIYyLB2/+2JfqGrrIrjiQvSVLtmgTQYj1YJ/ibYG3eFyrwXHwu0f0q6Jg==",
       "dev": true,
       "requires": {
-        "babel-eslint": "^10.1.0",
+        "@babel/core": "^7.12.16",
+        "@babel/eslint-parser": "^7.12.16",
         "eslint-visitor-keys": "^2.0.0",
         "esquery": "^1.3.1",
         "multimap": "^1.1.0"
@@ -21893,15 +21921,6 @@
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "split2": {
-          "version": "3.2.2",
-          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
-          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "^3.0.0"
           }
         },
         "strip-indent": {
@@ -26039,48 +26058,12 @@
       }
     },
     "split2": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
-      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
       "dev": true,
       "requires": {
-        "through2": "^2.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        },
-        "through2": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-          "dev": true,
-          "requires": {
-            "readable-stream": "~2.3.6",
-            "xtend": "~4.0.1"
-          }
-        }
+        "readable-stream": "^3.0.0"
       }
     },
     "sprintf-js": {
@@ -26418,9 +26401,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.0.tgz",
-          "integrity": "sha512-svS9uILze/cXbH0z2myCK2Brqprx/+JJYK5pHicT/GQiBfzzhUVAIT6MwqJg8y4xV/zoGsUeuPuwtoiKSGE15g==",
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.1.1.tgz",
+          "integrity": "sha512-ga/aqDYnUy/o7vbsRTFhhTsNeXiYb5JWDIcRIeZfwRNCefwjNTVYCGdGSUrEmiu3yDK3vFvNbgJxvrQW4JXrYQ==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -28033,9 +28016,9 @@
       },
       "dependencies": {
         "commander": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-7.0.0.tgz",
-          "integrity": "sha512-ovx/7NkTrnPuIV8sqk/GjUIIM1+iUQeqA3ye2VNpq9sVoiZsooObWlQy+OPWGI17GDaEoybuAGJm6U8yC077BA==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-7.1.0.tgz",
+          "integrity": "sha512-pRxBna3MJe6HKnBGsDyMv8ETbptw3axEdYHoqNh7gu5oDcew8fs0xnivZGm06Ogk8zGAJ9VX+OPEr2GXEQK4dg==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,9 @@
   "description": "Netlify Node.js API client",
   "version": "6.1.8",
   "files": [
-    "src",
-    "dist",
-    "!*.test.js*",
-    "!*~"
+    "src/**/*.js",
+    "!src/**/*.test.js",
+    "dist/main.js"
   ],
   "main": "./src/index.js",
   "unpkg": "./dist/main.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "files": [
     "src/**/*.js",
     "!src/**/*.test.js",
-    "dist/main.js"
+    "dist/main.js",
+    "dist/main.js.map"
   ],
   "main": "./src/index.js",
   "unpkg": "./dist/main.js",


### PR DESCRIPTION
npm 7 changed the way globbing patterns are interpreted in `files` in `package.json`. This is undocumented, so I'm not sure whether this is a bug or not. This results in all `*~` files (Vim temporary files) to be published to npm, which can double the package size. 

This PR fixes this. I ran `npm pack --dry` before and after to ensure no files were being omitted.

Before.: `199.1 KB` (packed), `928.8 KB` (unpacked)
After: `48.4 KB` (packed), `281.1 KB` (unpacked)