### PR TITLE
chore: use default rangeStrategy

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -4,7 +4,6 @@
   semanticCommits: true,
   masterIssue: true,
   automerge: false,
-  rangeStrategy: 'bump',
   packageRules: [
     {
       // Those cannot be upgraded to a major version until we drop support for Node 8


### PR DESCRIPTION
Use the default renovate strategy to avoid restricting ranges for non Netlify packages.

For Netlify packages we still use `bump` from https://github.com/netlify/renovate-config/blob/e7e66c5e8ec56923e0acfcb8b335564e86e7ff2d/default.json#L23

Should close https://github.com/netlify/js-client/pull/336