### PR TITLE
chore(release-please): use GitHub app token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - chore/use_gh_app
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,12 +3,18 @@ on:
   push:
     branches:
       - main
+      - chore/use_gh_app
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - uses: navikt/github-app-token-generator@2d70c12368d1958155af4d283f9f21c9a2a8cb98
+        id: get-token
+        with:
+          private-key: ${{ secrets.TOKENS_PRIVATE_KEY }}
+          app-id: ${{ secrets.TOKENS_APP_ID }}
       - uses: GoogleCloudPlatform/release-please-action@v2
         with:
-          token: ${{ secrets.NODE_PKG_RELEASE_TOKEN }}
+          token: ${{ steps.get-token.outputs.token }}
           release-type: node
           package-name: 'netlify'


### PR DESCRIPTION
Remove the usage of a personal access token in favor of a token generated from our GitHub app.
Advantages:
1. App tokens expire and scoped to a single repo
2. Better rate limits