### PR TITLE
fix: retry on `5**` responses

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -470,6 +470,22 @@ test('Can timeout access token polling', async (t) => {
   t.false(scope.isDone())
 })
 
+test('Retries on server errors', async (t) => {
+  const accountId = uuidv4()
+  const expectedResponse = { test: 'test' }
+  const scope = nock(origin)
+    .get(`${pathPrefix}/accounts/${accountId}`)
+    .reply(500)
+    .get(`${pathPrefix}/accounts/${accountId}`)
+    .reply(200, expectedResponse)
+
+  const client = getClient()
+  const response = await client.getAccount({ account_id: accountId })
+
+  t.deepEqual(response, expectedResponse)
+  t.true(scope.isDone())
+})
+
 test('Handles API rate limiting', async (t) => {
   const accountId = uuidv4()
   const retryAtMs = Date.now() + TEST_RATE_LIMIT_DELAY

--- a/src/methods/retry.js
+++ b/src/methods/retry.js
@@ -2,7 +2,11 @@
 //  - when receiving a rate limiting response
 //  - on network failures due to timeouts
 const shouldRetry = function ({ response = {}, error = {} }) {
-  return response.status === RATE_LIMIT_STATUS || RETRY_ERROR_CODES.has(error.code)
+  return isRetryStatus(response) || RETRY_ERROR_CODES.has(error.code)
+}
+
+const isRetryStatus = function ({ status }) {
+  return typeof status === 'number' && (status === RATE_LIMIT_STATUS || String(status).startsWith('5'))
 }
 
 const waitForRetry = async function (response) {


### PR DESCRIPTION
Part of https://github.com/netlify/bitballoon/issues/9616

This makes the `js-client` retry on any `5**` error response.