### PR TITLE
fix: add `ECONNRESET` to `error.code`

### DIFF
--- a/src/methods/retry.js
+++ b/src/methods/retry.js
@@ -36,6 +36,6 @@ const SECS_TO_MSECS = 1e3
 const MAX_RETRY = 10
 const RATE_LIMIT_STATUS = 429
 const RATE_LIMIT_HEADER = 'X-RateLimit-Reset'
-const RETRY_ERROR_CODES = new Set(['ETIMEDOUT'])
+const RETRY_ERROR_CODES = new Set(['ETIMEDOUT', 'ECONNRESET'])
 
 module.exports = { shouldRetry, waitForRetry, MAX_RETRY }


### PR DESCRIPTION
Part of https://github.com/netlify/bitballoon/issues/9616

This makes the `js-client` retry on any `ECONNRESET` error response. This happens when the TCP socket is closed, which happens from time to time in production due to transient reasons.