### PR TITLE
chore: simplify renovate.json5

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -3,7 +3,6 @@
   ignorePresets: [':prHourlyLimit2'],
   semanticCommits: true,
   dependencyDashboard: true,
-  automerge: true,
   packageRules: [
     {
       // Those cannot be upgraded to a major version


### PR DESCRIPTION
This simplifies `renovate.json5` since we can re-use the default value.