### PR TITLE
feat: add support for header parameters

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -253,6 +253,31 @@ test('Can use global parameters in request body', async (t) => {
   t.true(scope.isDone())
 })
 
+test('Can set header parameters', async (t) => {
+  const deployId = uuidv4()
+  const functionName = 'testFunction'
+  const body = 'test'
+  const expectedResponse = { test: 'test' }
+  const retryCount = 3
+  const scope = nock(origin)
+    .put(`${pathPrefix}/deploys/${deployId}/functions/${functionName}`, body, {
+      'Content-Type': 'application/octet-stream',
+    })
+    .matchHeader('X-Nf-Retry-Count', retryCount.toString())
+    .reply(200, expectedResponse)
+
+  const client = getClient()
+  const response = await client.uploadDeployFunction({
+    deploy_id: deployId,
+    name: functionName,
+    body: fromString(body),
+    xNfRetryCount: retryCount,
+  })
+
+  t.deepEqual(response, expectedResponse)
+  t.true(scope.isDone())
+})
+
 test('Validates required path parameters', async (t) => {
   const accountId = uuidv4()
   const scope = nock(origin).put(`${pathPrefix}/accounts/${accountId}`).reply(200)

--- a/src/methods/params.js
+++ b/src/methods/params.js
@@ -1,0 +1,18 @@
+import camelCase from 'lodash.camelcase'
+
+export const getRequestParams = function (params, requestParams, name) {
+  const entries = Object.values(params).map((param) => getRequestParam(param, requestParams, name))
+  return Object.assign({}, ...entries)
+}
+
+const getRequestParam = function (param, requestParams, name) {
+  const value = requestParams[param.name] || requestParams[camelCase(param.name)]
+
+  if (value !== undefined) {
+    return { [param.name]: value }
+  }
+
+  if (param.required) {
+    throw new Error(`Missing required ${name} '${param.name}'`)
+  }
+}

--- a/src/methods/url.js
+++ b/src/methods/url.js
@@ -1,5 +1,6 @@
-import camelCase from 'lodash.camelcase'
 import queryString from 'qs'
+
+import { getRequestParams } from './params.js'
 
 // Replace path parameters and query parameters in the URI, using the OpenAPI
 // definition
@@ -27,21 +28,4 @@ const addQueryParams = function (url, parameters, requestParams) {
   }
 
   return `${url}?${queryString.stringify(queryParams, { arrayFormat: 'brackets' })}`
-}
-
-const getRequestParams = function (params, requestParams, name) {
-  const entries = Object.values(params).map((param) => getRequestParam(param, requestParams, name))
-  return Object.assign({}, ...entries)
-}
-
-const getRequestParam = function (param, requestParams, name) {
-  const value = requestParams[param.name] || requestParams[camelCase(param.name)]
-
-  if (value !== undefined) {
-    return { [param.name]: value }
-  }
-
-  if (param.required) {
-    throw new Error(`Missing required ${name} '${param.name}'`)
-  }
 }


### PR DESCRIPTION
#### Summary

The Open API spec allows [header parameters](https://swagger.io/docs/specification/describing-parameters/#header-parameters), which are currently being ignored by the JS client. This PR addresses that.

Part of https://github.com/netlify/pod-compute/issues/140.
