### PR TITLE
feat!: stop retrying on 5xx responses

### DIFF
--- a/src/methods/index.js
+++ b/src/methods/index.js
@@ -76,7 +76,7 @@ const makeRequestOrRetry = async function ({ url, method, defaultHeaders, agent,
     const optsA = getOpts({ method, defaultHeaders, agent, requestParams, opts })
     const { response, error } = await makeRequest(url, optsA)
 
-    if (shouldRetry({ response, error }) && index !== MAX_RETRY) {
+    if (shouldRetry({ response, error, method }) && index !== MAX_RETRY) {
       await waitForRetry(response)
       continue
     }


### PR DESCRIPTION
#### Summary

The JavaScript API client currently has a [global retry mechanism](https://github.com/netlify/js-client/blob/main/src/methods/retry.js#L9) that will retry on 429 and 5xx responses. At the same time, there's a [a separate retry mechanism for file and function uploads](https://github.com/netlify/cli/blob/main/src/utils/deploy/upload-files.js#L26-L57) in the CLI, which retries any error.

This means that for any 5xx errors happening in function or file uploads, there are two separate retry mechanisms kicking in in the CLI.

In contrast, the Go API client has [a global retry mechanism at the transport level](https://github.com/netlify/open-api/blob/master/go/porcelain/http/http.go#L59-L76), which retries only on responses with the 429 status code, and [a separate retry mechanism for file and function uploads](https://github.com/netlify/open-api/blob/master/go/porcelain/deploy.go#L460-L518).

This PR makes the JavaScript client aligned with the Go client, by making the global retry only handle 429s.

There is one exception, though. In https://github.com/netlify/bitballoon/issues/9616, we've added retries to 5xx errors because of a specific endpoint that occasionally failed. In order to avoid disruption, this PR contains a special case for that endpoint, keeping the existing behaviour.

I would recommend that we remove that special case in a future release.